### PR TITLE
requirement.txt可以方便的安装依赖

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml

--- a/.idea/CodeCrafter-macOS-Finder.iml
+++ b/.idea/CodeCrafter-macOS-Finder.iml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.11 (CodeCrafter-macOS-Finder)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (CodeCrafter-macOS-Finder)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/CodeCrafter-macOS-Finder.iml" filepath="$PROJECT_DIR$/.idea/CodeCrafter-macOS-Finder.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/main.py
+++ b/main.py
@@ -99,7 +99,7 @@ class Finder:
     def display_folder_content(self, folder_path):
         self.canvas.config(scrollregion=self.canvas.bbox("all"))
         self.canvas.delete("all")
-        self.thumbnail_photos=[] #及时清空图片缓存，防止成为下一个electron
+        self.thumbnail_photos=[] #及时清空图片缓存，防止成为下一个chromium
         x_offset = 210
         y_offset = 20
         max_width = self.root.winfo_width() - 150
@@ -196,6 +196,14 @@ class Finder:
         self.canvas.move(text_id, delta_x, delta_y)
         self._drag_data['x'] = event.x
         self._drag_data['y'] = event.y
+
+    # 参考代码：如果文件或文件家名称过长，将会以省略号缩略显示，比如如果文件名称长度超过10个文字，将会缩略显示
+    # def get_abbreviated_file_name(file_path, max_length=10):
+    #     file_name = os.path.basename(file_path)
+    #     if len(file_name) > max_length:
+    #         return file_name[:max_length] + "..."
+    #     else:
+    #         return file_name
 
 root = Tk()
 finder = Finder(root)

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,0 +1,6 @@
+pillow
+tkintertools
+pygame
+tkinter
+subprocess
+threading


### PR DESCRIPTION
# requirement.txt
它可以用来快速安装依赖模块，输入`pip install -r requirement.txt`即可一键安装

# 文件名显示长度问题
如果某个文件名字过长，将会遮住文件图标，影响正常使用。我这里留了一些代码，你们可以去参考一下（因为我看不懂代码）